### PR TITLE
Fixed case where sorting on 'table name.columnname'; added unit tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -200,7 +200,8 @@ export default (Bookshelf, options = {}) => {
 
                     // Determine if the sort should be descending
                     if (typeof sortValues[i] === 'string' && sortValues[i][0] === '-') {
-                        sortDesc.push(sortValues[i].substring(1, sortValues[i].length));
+                        sortValues[i] = sortValues[i].substring(1, sortValues[i].length);
+                        sortDesc.push(sortValues[i]);
                     }
                 }
 


### PR DESCRIPTION
We are using bookshelf-jsonapi-params but we ran into an issue where a descending sort on a column of the format '-tablename.columnname' wasn't working.  I saw that you updated the library for just this bug (issue #12 ) a few days ago but for us it wasn't resolved.  This pull request fixes the issue as well as adds a test case to the unit tests.  I had to modify the formatter for the model used in the unit tests to support the tablename.columnname format.
