### PR TITLE
Add support for aggregate functions and group by

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ If you're returning a single resource from a call such as `GET /customers/1`, ma
 `options`    | Description
 :------------- | :-------------
 filter _object_  | Filters a result set based specific field. Example: `/pets?filter[name]=max` would only return pets named max. Keywords can be added to filters to give more control over the results. Example: `/pets?filterType[like][pet]=ax` would only return pets that have "ax" in their name. The supported types are "like", "not", "lt", "lte", "gt", and "gte". Both "like" and "not" support multiple values by comma separation. Also, if your data has a string with a comma, you can filter for that comma by escaping the character with two backslashes. NOTE: This is not supported by JSON API spec.
-fields _object_   | Limits the fields returned as part of the record. Example: `/pets?fields[pets]=name` would return pet records with only the name field rather than every field.
+fields _object_   | Limits the fields returned as part of the record. Example: `/pets?fields[pets]=name` would return pet records with only the name field rather than every field. _Note:_ you may use aggregate functions such as `/pets?fields[pets]=count(id)`. Supported aggregate functions are "count", "sum", "avg", "max", "min".
 include _array_  | Returns relationships as part of the payload. Example: `/pets?include=owner` would return the pet record in addition to the full record of its owner. _Note:_ you may override an `include` parameter with your own Knex function rather than just a string representing the relationship name.
 page _object/false_  | Paginates the result set. Example: `/pets?page[limit]=25&page[offset]=0` would return the first 25 records. If you've passed default pagination parameters to the plugin, but would like to disable paging on a specific call, just set `page` to `false`.
 sort _array_     | Sorts the result set by specific fields. Example: `/pets?sort=-weight,birthDate` would return the records sorted by `weight` descending, then `birthDate` ascending
+group _array_     | Use it with `fields` param to group your results. Example: `/pets?fields[pets]=avg(age),gender&group=gender` would return return the average age of pets per gender. NOTE: This is not supported by JSON API spec.
 
 See the **[specific section of the JSON API spec](http://jsonapi.org/format/#fetching-includes)** that deals with these parameters for more information.
 

--- a/src/index.js
+++ b/src/index.js
@@ -267,13 +267,13 @@ export default (Bookshelf, options = {}) => {
 
                         // Extract any aggregate function around the column name
                         let column = value;
-                        let aggregateFunction = value.split('(')[0];
-                        const aggregateFunctions = ['count', 'sum', 'avg', 'max', 'min'];
+                        let aggregateFunction = null;
+                        const regex = new RegExp(/(count|sum|avg|max|min)\((.+)\)/g);
+                        const match = regex.exec(value);
 
-                        if (_includes(aggregateFunctions, aggregateFunction)) {
-                            column = column.split('(')[1].split(')')[0];
-                        } else {
-                            aggregateFunction = false;
+                        if (match) {
+                            aggregateFunction = match[1];
+                            column = match[2];
                         }
 
                         if (!fieldKey) {

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export default (Bookshelf, options = {}) => {
         opts = opts || {};
 
         const internals = {};
-        const { include, fields, sort, page = {}, filter } = opts;
+        const { include, fields, sort, page = {}, filter, group } = opts;
         const filterTypes = ['like', 'not', 'lt', 'gt', 'lte', 'gte'];
 
         // Get a reference to the field being used as the id
@@ -73,7 +73,7 @@ export default (Bookshelf, options = {}) => {
             this.constructor.prototype.idAttribute : 'id';
 
         // Get a reference to the current model name. Note that if no type is
-        // explcitly passed, the tableName will be used
+        // explicitly passed, the tableName will be used
         internals.modelName = type ? type : this.constructor.prototype.tableName;
 
         // Initialize an instance of the current model and clone the initial query
@@ -81,14 +81,15 @@ export default (Bookshelf, options = {}) => {
             this.constructor.forge().query((qb) => _assign(qb, this.query().clone()));
 
         /**
-         * Build a query for relational dependencies of filtering and sorting
+         * Build a query for relational dependencies of filtering, grouping and sorting
          * @param   filterValues {object}
+         * @param   groupValues {object}
          * @param   sortValues {object}
          */
-        internals.buildDependencies = (filterValues, sortValues) => {
+        internals.buildDependencies = (filterValues, groupValues, sortValues) => {
 
             const relationHash = {};
-            // Find relations in fitlerValues
+            // Find relations in filterValues
             if (_isObjectLike(filterValues) && !_isEmpty(filterValues)){
 
                 // Loop through each filter value
@@ -126,10 +127,20 @@ export default (Bookshelf, options = {}) => {
                 });
             }
 
+            // Find relations in groupValues
+            if (_isObjectLike(groupValues) && !_isEmpty(groupValues)){
+
+                // Loop through each group value
+                _forEach(groupValues, (value) => {
+
+                    // Add relations to the relationHash
+                    internals.buildDependenciesHelper(value, relationHash);
+                });
+            }
+
             // Need to select model.* so all of the relations are not returned, also check if there is anything in fields object
             if (_keys(relationHash).length && !_keys(fields).length){
                 internals.model.query((qb) => {
-
                     qb.select(`${internals.modelName}.*`);
                 });
             }
@@ -254,19 +265,31 @@ export default (Bookshelf, options = {}) => {
                     // Add qualifying table name to avoid ambiguous columns
                     fieldNames[fieldKey] = _map(fieldNames[fieldKey], (value) => {
 
-                        if (!fieldKey){
-                            if (_includes(value, '.')){
-                                return value;
-                            }
-                            return `${internals.modelName}.${value}`;
+                        // Extract any aggregate function around the column name
+                        let column = value;
+                        let aggregateFunction = value.split('(')[0];
+                        const aggregateFunctions = ['count', 'sum', 'avg', 'max', 'min'];
+
+                        if (_includes(aggregateFunctions, aggregateFunction)) {
+                            column = column.split('(')[1].split(')')[0];
+                        } else {
+                            aggregateFunction = false;
                         }
-                        return `${fieldKey}.${value}`;
+
+                        if (!fieldKey) {
+                            if (!_includes(column, '.')) {
+                                column = `${internals.modelName}.${column}`;
+                            }
+                        } else {
+                            column = `${fieldKey}.${column}`;
+                        }
+
+                        return aggregateFunction ? { aggregateFunction, column } : column;
                     });
 
                     // Only process the field if it's not a relation. Fields
                     // for relations are processed in `buildIncludes()`
                     if (!_includes(include, fieldKey)) {
-
 
                         // Add columns to query
                         internals.model.query((qb) => {
@@ -275,7 +298,14 @@ export default (Bookshelf, options = {}) => {
                                 qb.distinct();
                             }
 
-                            qb.select(fieldNames[fieldKey]);
+                            _forEach(fieldNames[fieldKey], (column) => {
+
+                                if (column.aggregateFunction) {
+                                    qb[column.aggregateFunction](column.column);
+                                } else {
+                                    qb.select([column]);
+                                }
+                            });
 
                             // JSON API considers relationships as fields, so we
                             // need to make sure the id of the relation is selected
@@ -521,6 +551,26 @@ export default (Bookshelf, options = {}) => {
         };
 
         /**
+         * Build a query based on the `group` parameter.
+         * @param  groupValues {array}
+         */
+        internals.buildGroup = (groupValues = []) => {
+
+            if (_isArray(groupValues) && !_isEmpty(groupValues)) {
+
+                groupValues = internals.formatColumnNames(groupValues);
+
+                internals.model.query((qb) => {
+
+                    _forEach(groupValues, (groupBy) => {
+
+                        qb.groupBy(groupBy);
+                    });
+                });
+            }
+        };
+
+        /**
          * Processes incoming parameters that represent columns names and
          * formats them using the internal {@link Model#format} function.
          * @param  columnNames {array}
@@ -632,18 +682,20 @@ export default (Bookshelf, options = {}) => {
         /// Process parameters
         ////////////////////////////////
 
-        // Apply relational dependencies for filters and sorting
-        internals.buildDependencies(filter, sort);
+        // Apply relational dependencies for filters, grouping and sorting
+        internals.buildDependencies(filter, group, sort);
 
         // Apply filters
         internals.buildFilters(filter);
+
+        // Apply grouping
+        internals.buildGroup(group);
 
         // Apply sorting
         internals.buildSort(sort);
 
         // Apply relations
         internals.buildIncludes(include);
-
 
         // Apply sparse fieldsets
         internals.buildFields(fields);

--- a/src/index.js
+++ b/src/index.js
@@ -301,7 +301,7 @@ export default (Bookshelf, options = {}) => {
                             _forEach(fieldNames[fieldKey], (column) => {
 
                                 if (column.aggregateFunction) {
-                                    qb[column.aggregateFunction](column.column);
+                                    qb[column.aggregateFunction](`${column.column} as ${column.aggregateFunction}`);
                                 } else {
                                     qb.select([column]);
                                 }

--- a/test/index.js
+++ b/test/index.js
@@ -52,7 +52,7 @@ describe('bookshelf-jsonapi-params', () => {
 
                 const aggregateFunctions = ['count', 'sum', 'avg', 'max', 'min'];
 
-                if (aggregateFunctions.some(f => key.includes(f))) {
+                if (_.some(aggregateFunctions, (f) => _.startsWith(key, f + '('))) {
                     result[key] = val;
                 } else {
                     result[_.snakeCase(key)] = val;


### PR DESCRIPTION
Hi,

The JSON API spec is missing aggregate functions and "group by" so I added support for that!

You can use "count", "sum", "avg", "max", "min" in `fields` like this:
     
    /pets?fields[pets]=avg(age)

 There's also a `group` array parameter that you can use with `fields` as follows:
    
    /pets?fields[pets]=avg(age),gender&group=gender
    ---> returns the average age of pets per gender

This is a simple example but you may add other properties in the `group` and `fields`.

I also added a few tests and updated the readme. Tell me if some things could be changed/improved.

Hope you like it 😄 