### PR TITLE
 Fixed MySQL compatibility problems, added new filter feature for filtering like on non text fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,8 @@
   },
   "homepage": "https://github.com/scoutforpets/bookshelf-jsonapi-params",
   "devDependencies": {
-    "babel": "6.5.2",
-    "babel-cli": "6.9.0",
-    "babel-core": "6.9.1",
+    "babel-cli": "6.26.0",
+    "babel-core": "6.26.0",
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-plugin-syntax-object-rest-spread": "6.8.0",
     "babel-plugin-transform-object-rest-spread": "6.8.0",

--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,13 @@ export default (Bookshelf, options = {}) => {
         // explicitly passed, the tableName will be used
         internals.modelName = type ? type : this.constructor.prototype.tableName;
 
+        // Used to determine which casting syntax is valid
+        internals.client = Bookshelf.knex.client.config.client;
+        internals.textType = 'text';
+        if (internals.client === 'mysql' && internals.client === 'mssql'){
+            internals.textType = 'char';
+        }
+
         // Initialize an instance of the current model and clone the initial query
         internals.model =
             this.constructor.forge().query((qb) => _assign(qb, this.query().clone()));
@@ -372,7 +379,7 @@ export default (Bookshelf, options = {}) => {
                                                 _forEach(valueArray, (val) => {
 
                                                     qbWhere[where](
-                                                        Bookshelf.knex.raw('LOWER(CAST(:typeKey: AS text)) like LOWER(:value)', {
+                                                        Bookshelf.knex.raw(`LOWER(CAST(:typeKey: AS ${internals.textType})) like LOWER(:value)`, {
                                                             value: `%${val}%`,
                                                             typeKey
                                                         })
@@ -386,7 +393,7 @@ export default (Bookshelf, options = {}) => {
                                             }
                                             else {
                                                 qbWhere.where(
-                                                    Bookshelf.knex.raw('LOWER(CAST(:typeKey: AS text)) like LOWER(:value)', {
+                                                    Bookshelf.knex.raw(`LOWER(CAST(:typeKey: AS ${internals.textType})) like LOWER(:value)`, {
                                                         value: `%${val}%`,
                                                         typeKey
                                                     })

--- a/src/index.js
+++ b/src/index.js
@@ -365,18 +365,17 @@ export default (Bookshelf, options = {}) => {
                                     // Attach different query for each type
                                     if (key === 'like'){
 
-                                        // Need to add double quotes for each table/column name, this is needed if there is a relationship with a capital letter
-                                        const formatedKey = `"${typeKey.replace('.', '"."')}"`;
                                         qb.where((qbWhere) => {
 
                                             if (_isArray(valueArray)){
                                                 let where = 'where';
                                                 _forEach(valueArray, (val) => {
 
-                                                    val = `%${val}%`;
-
                                                     qbWhere[where](
-                                                        Bookshelf.knex.raw(`LOWER(${formatedKey}) like LOWER(?)`, [val])
+                                                        Bookshelf.knex.raw('LOWER(CAST(:typeKey: AS text)) like LOWER(:value)', {
+                                                            value: `%${val}%`,
+                                                            typeKey
+                                                        })
                                                     );
 
                                                     // Change to orWhere after the first where
@@ -387,7 +386,10 @@ export default (Bookshelf, options = {}) => {
                                             }
                                             else {
                                                 qbWhere.where(
-                                                    Bookshelf.knex.raw(`LOWER(${formatedKey}) like LOWER(?)`, [`%${typeValue}%`])
+                                                    Bookshelf.knex.raw('LOWER(CAST(:typeKey: AS text)) like LOWER(:value)', {
+                                                        value: `%${val}%`,
+                                                        typeKey
+                                                    })
                                                 );
                                             }
 

--- a/test/index.js
+++ b/test/index.js
@@ -611,6 +611,7 @@ describe('bookshelf-jsonapi-params', () => {
     });
 
     describe('escape commas in filter', () => {
+
         it('should escape the comma and find a result', (done) => {
             PersonModel
                 .fetchJsonApi({
@@ -640,6 +641,30 @@ describe('bookshelf-jsonapi-params', () => {
         });
     });
 
+    describe('like filtering on non-text fields', () => {
+
+        it('should return the should return all record that have an age that contains the digit "2"', (done) => {
+
+            PersonModel
+                .forge()
+                .fetchJsonApi({
+                    filter: {
+                        like: {
+                            age: '2'
+                        }
+                    }
+                })
+                .then((result) => {
+
+                    expect(result.models).to.have.length(3);
+                    expect(result.models[0].get('firstName')).to.equal('Barney');
+                    expect(result.models[1].get('firstName')).to.equal('Baby Bop');
+                    expect(result.models[2].get('firstName')).to.equal('Boo');
+                    done();
+                });
+        });
+    });
+
     describe('passing a `fields` parameter with an aggregate function', () => {
 
         it('should return the total count of records', (done) => {
@@ -664,7 +689,7 @@ describe('bookshelf-jsonapi-params', () => {
                 .forge()
                 .fetchJsonApi({
                     fields: {
-                        person: ['avg(age)','gender'],
+                        person: ['avg(age)','gender']
                     },
                     group: ['gender']
                 })
@@ -689,8 +714,8 @@ describe('bookshelf-jsonapi-params', () => {
                         }
                     },
                     fields: {
-                        person: ['sum(age)'],
-                    },
+                        person: ['sum(age)']
+                    }
                 })
                 .then((result) => {
                     expect(result.models).to.have.length(1);


### PR DESCRIPTION
This fixes the issue with other SQL syntax for columns on the LIKE filtering. I used the method as described in knex documentation here: [http://knexjs.org/#Raw-Bindings](http://knexjs.org/#Raw-Bindings).
This solved #26 

This also adds a new feature where you can search over any non text column with the like filtering, solves #37 