### PR TITLE
Sorting on deeply nested resources

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -554,7 +554,10 @@ export default (Bookshelf, options = {}) => {
 
                 _forEach(sortValues, (sortBy) => {
 
-                    internals.model.orderBy(sortBy, sortDesc.indexOf(sortBy) === -1 ? 'asc' : 'desc');
+                    internals.model.orderBy(
+                        sortBy && internals.formatRelation(sortBy),
+                        sortDesc.indexOf(sortBy) === -1 ? 'asc' : 'desc'
+                    );
                 });
             }
         };

--- a/src/index.js
+++ b/src/index.js
@@ -554,10 +554,12 @@ export default (Bookshelf, options = {}) => {
 
                 _forEach(sortValues, (sortBy) => {
 
-                    internals.model.orderBy(
-                        sortBy && internals.formatRelation(sortBy),
-                        sortDesc.indexOf(sortBy) === -1 ? 'asc' : 'desc'
-                    );
+                    if (sortBy) {
+                        internals.model.orderBy(
+                            internals.formatRelation(sortBy),
+                            sortDesc.indexOf(sortBy) === -1 ? 'asc' : 'desc'
+                        );
+                    }
                 });
             }
         };


### PR DESCRIPTION
Hi,

    /persons?include=pets,pets.toy&sort=-pets.toy.type

didn't work and produced the following query:
    
    select "person".* from "person" left outer join "pet" as "pets" on "person"."id" = "pets"."person_id" left outer join "toy" as "toy" on "pets"."id" = "toy"."pet_id" order by "pets"."toy"."type" desc

I used the `formatRelation` function so that the `order by` part is now correct:
    
    order by "toy"."type" desc

As usual, I added a test.

Cheers,