### PR TITLE
Filter not null values and filter null as string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -409,6 +409,10 @@ export default (Bookshelf, options = {}) => {
                                         });
                                     }
                                     else if (key === 'not'){
+                                        if (valueArray.includes('null')) {
+                                            qb.whereNotNull(typeKey);
+                                            valueArray = valueArray.filter((val) => val !== 'null');
+                                        }
                                         qb.whereNotIn(typeKey, valueArray);
                                     }
                                     else if (key === 'lt'){

--- a/src/index.js
+++ b/src/index.js
@@ -363,7 +363,7 @@ export default (Bookshelf, options = {}) => {
                                     // Determine if there are multiple filters to be applied
                                     let valueArray = null;
                                     if (!_isArray(typeValue)){
-                                        valueArray = split(typeValue.toString(), ',');
+                                        valueArray = typeValue !== null && typeValue !== 'null' ? split(typeValue.toString(), ',') : [null];
                                     }
                                     else {
                                         valueArray = typeValue;
@@ -409,9 +409,9 @@ export default (Bookshelf, options = {}) => {
                                         });
                                     }
                                     else if (key === 'not'){
-                                        if (valueArray.includes('null')) {
+                                        if (valueArray.find((val) => val === null || val === 'null') !== undefined) {
                                             qb.whereNotNull(typeKey);
-                                            valueArray = valueArray.filter((val) => val !== 'null');
+                                            valueArray = valueArray.filter((val) => val !== null && val !== 'null');
                                         }
                                         qb.whereNotIn(typeKey, valueArray);
                                     }
@@ -436,7 +436,7 @@ export default (Bookshelf, options = {}) => {
                             if (!_hasIn(filterValues.like, key)){
                                 // Remove all but the last table name, need to get number of dots
                                 key = internals.formatRelation(internals.formatColumnNames([key])[0]);
-
+                                value = value === 'null' ? null : value;
 
                                 if (_isNull(value)){
                                     qb.where(key, value);
@@ -446,7 +446,11 @@ export default (Bookshelf, options = {}) => {
                                     if (!_isArray(value)){
                                         value = split(value.toString(), ',');
                                     }
-                                    qb.whereIn(key, value);
+                                    if (value.find((val) => val === 'null' || val === null) !== undefined){
+                                        qb.whereNull(key);
+                                        value = value.filter((val) => val !== 'null' && val !== null);
+                                    }
+                                    qb.orWhereIn(key, value);
                                 }
                             }
                         }

--- a/test/index.js
+++ b/test/index.js
@@ -300,6 +300,22 @@ describe('bookshelf-jsonapi-params', () => {
                     done();
                 });
         });
+
+        it('should return a single record that matches both filters with a null', (done) => {
+
+            PersonModel
+                .forge()
+                .fetchJsonApi({
+                    filter: {
+                        type: 'null,t-rex'
+                    }
+                })
+                .then((result) => {
+
+                    expect(result.models).to.have.length(2);
+                    done();
+                });
+        });
     });
 
     describe('passing a `filter[like]` parameter with a single filter', () => {
@@ -371,6 +387,48 @@ describe('bookshelf-jsonapi-params', () => {
                     done();
                 });
         });
+
+        it('should return all records that do not match filter[not] with null', (done) => {
+
+            PersonModel
+                .forge()
+                .fetchJsonApi({
+                    filter: {
+                        not: {
+                            type: null
+                        }
+                    }
+                })
+                .then((result) => {
+                    expect(result.models).to.have.length(4);
+                    expect(result.models[0].get('type')).to.equal('t-rex');
+                    expect(result.models[1].get('type')).to.equal('triceratops');
+                    expect(result.models[2].get('type')).to.equal('monster');
+                    expect(result.models[3].get('type')).to.equal('nothing, here');
+                    done();
+                });
+        });
+
+        it('should return all records that do not match filter[not] with null as a string', (done) => {
+
+            PersonModel
+                .forge()
+                .fetchJsonApi({
+                    filter: {
+                        not: {
+                            type: 'null'
+                        }
+                    }
+                })
+                .then((result) => {
+                    expect(result.models).to.have.length(4);
+                    expect(result.models[0].get('type')).to.equal('t-rex');
+                    expect(result.models[1].get('type')).to.equal('triceratops');
+                    expect(result.models[2].get('type')).to.equal('monster');
+                    expect(result.models[3].get('type')).to.equal('nothing, here');
+                    done();
+                });
+        });
     });
 
     describe('passing a `filter[not]` parameter with multiple filters', () => {
@@ -390,6 +448,26 @@ describe('bookshelf-jsonapi-params', () => {
 
                     expect(result.models).to.have.length(1);
                     expect(result.models[0].get('firstName')).to.equal('Cookie Monster');
+                    done();
+                });
+        });
+
+        it('should return all records that do not match filter[not] including null', (done) => {
+
+            PersonModel
+                .forge()
+                .fetchJsonApi({
+                    filter: {
+                        not: {
+                            type: 'null,t-rex'
+                        }
+                    }
+                })
+                .then((result) => {
+                    expect(result.models).to.have.length(3);
+                    expect(result.models[0].get('type')).to.equal('triceratops');
+                    expect(result.models[1].get('type')).to.equal('monster');
+                    expect(result.models[2].get('type')).to.equal('nothing, here');
                     done();
                 });
         });


### PR DESCRIPTION
I noticed we weren't able to filter values by `not null`, which can be pretty convenient
We can now have filters like this `filter[not][xxx]=null` or `filter[not][xxx]=null,10`.
The case where `null` was a string was not working either (when coming from url) for the basic `filter` so I also handled this.

Let me know if something needs a change.

Thanks.