### PR TITLE
Maintaining quotes when splitting strings to build filters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -377,7 +377,7 @@ export default (Bookshelf, options = {}) => {
                                     // Determine if there are multiple filters to be applied
                                     let valueArray = null;
                                     if (!_isArray(typeValue)){
-                                        valueArray = typeValue !== null && typeValue !== 'null' ? split(typeValue.toString(), ',') : [null];
+                                        valueArray = typeValue !== null && typeValue !== 'null' ? split(typeValue.toString(), { keepQuotes: true, sep: ',' }) : [null];
                                     }
                                     else {
                                         valueArray = typeValue;
@@ -458,7 +458,7 @@ export default (Bookshelf, options = {}) => {
                                 else {
                                     // Determine if there are multiple filters to be applied
                                     if (!_isArray(value)){
-                                        value = split(value.toString(), ',');
+                                        value = split(value.toString(), { keepQuotes: true, sep: ',' });
                                     }
                                     if (value.find((val) => val === null || val === 'null') !== undefined){
                                         value = value.filter((val) => val !== 'null' && val !== null);

--- a/test/index.js
+++ b/test/index.js
@@ -187,6 +187,11 @@ describe('bookshelf-jsonapi-params', () => {
                         name: 'Grover',
                         pet_owner_id: 1
                     }),
+                    PetModel.forge().save({
+                        id: 5,
+                        name: 'Benny "The Terror" Terrier',
+                        pet_owner_id: 2
+                    }),
                     ToyModel.forge().save({
                         id: 1,
                         type: 'skate',
@@ -950,6 +955,26 @@ describe('bookshelf-jsonapi-params', () => {
         });
     });
 
+    describe('Filtering by string values which contain quotes', () => {
+
+        it('should maintain quotes when it builds the filter', (done) => {
+
+            PetModel
+                .forge()
+                .fetchJsonApi({
+                    filter: {
+                        name: 'Benny "The Terror" Terrier'
+                    }
+                })
+                .then((result) => {
+
+                    expect(result.models).to.have.length(1);
+                    done();
+                });
+        });
+    });
+
+
 
     describe('Sorting by multiple columns with a mix of camelCase values', () => {
 
@@ -962,9 +987,9 @@ describe('bookshelf-jsonapi-params', () => {
                 })
                 .then((result) => {
 
-                    expect(result.models).to.have.length(4);
-                    expect(result.models[2].get('name')).to.equal('Big Bird');
-                    expect(result.models[3].get('name')).to.equal('Grover');
+                    expect(result.models).to.have.length(5);
+                    expect(result.models[3].get('name')).to.equal('Big Bird');
+                    expect(result.models[4].get('name')).to.equal('Grover');
                     done();
                 });
         });


### PR DESCRIPTION
The added test case will fail on the current master. I am under the assumption we are using that split library for a reason, but to continue to use it, it needs this extra option.